### PR TITLE
Fix configuration model issues

### DIFF
--- a/src/backend/command/model/configuration/__init__.py
+++ b/src/backend/command/model/configuration/__init__.py
@@ -28,7 +28,7 @@ from ._condition import CMDConditionOperator, \
     CMDConditionAndOperator, CMDConditionOrOperator, CMDConditionNotOperator, CMDConditionHasValueOperator, \
     CMDCondition
 from ._configuration import CMDConfiguration
-from ._content import CMDJson
+from ._content import CMDRequestJson, CMDResponseJson
 from ._example import CMDCommandExample
 from ._fields import CMDBooleanField, CMDStageEnum, CMDStageField, CMDVariantField, CMDClassField, \
     CMDPrimitiveField, CMDRegularExpressionField, CMDVersionField, CMDResourceIdField, CMDCommandNameField, \
@@ -40,7 +40,8 @@ from ._http import CMDHttpRequestArgs, CMDHttpRequestPath, CMDHttpRequestQuery, 
     CMDHttpRequest, \
     CMDHttpResponseHeaderItem, CMDHttpResponseHeader, CMDHttpResponse, \
     CMDHttpAction
-from ._http_body import CMDHttpBody, CMDHttpJsonBody
+from ._http_request_body import CMDHttpRequestBody, CMDHttpRequestJsonBody
+from ._http_response_body import CMDHttpResponseBody, CMDHttpResponseJsonBody
 from ._instance_update import CMDInstanceUpdateAction, \
     CMDJsonInstanceUpdateAction, \
     CMDGenericInstanceUpdateMethod, CMDGenericInstanceUpdateAction

--- a/src/backend/command/model/configuration/_arg.py
+++ b/src/backend/command/model/configuration/_arg.py
@@ -128,14 +128,13 @@ class CMDArgBase(Model):
 
 class CMDArgBaseField(PolyModelType):
 
-    def __init__(self, support_arg=False, **kwargs):
+    def __init__(self, **kwargs):
         super(CMDArgBaseField, self).__init__(
             model_spec=CMDArgBase,
             allow_subclasses=True,
             serialize_when_none=False,
             **kwargs
         )
-        self.support_arg = support_arg
 
     def find_model(self, data):
         if self.claim_function:
@@ -147,12 +146,9 @@ class CMDArgBaseField(PolyModelType):
         fallback = None
         matching_classes = set()
         for kls in self._get_candidates():
-            if self.support_arg:
-                if not issubclass(kls, CMDArg) and "var" in data:
-                    continue
-            else:
-                if issubclass(kls, CMDArg):
-                    continue
+            if issubclass(kls, CMDArg):
+                continue
+
             try:
                 kls_claim = kls._claim_polymorphic
             except AttributeError:

--- a/src/backend/command/model/configuration/_arg.py
+++ b/src/backend/command/model/configuration/_arg.py
@@ -126,6 +126,50 @@ class CMDArgBase(Model):
         self._reformat_base()
 
 
+class CMDArgBaseField(PolyModelType):
+
+    def __init__(self, support_arg=False, **kwargs):
+        super(CMDArgBaseField, self).__init__(
+            model_spec=CMDArgBase,
+            allow_subclasses=True,
+            serialize_when_none=False,
+            **kwargs
+        )
+        self.support_arg = support_arg
+
+    def find_model(self, data):
+        if self.claim_function:
+            kls = self.claim_function(self, data)
+            if not kls:
+                raise Exception("Input for polymorphic field did not match any model")
+            return kls
+
+        fallback = None
+        matching_classes = set()
+        for kls in self._get_candidates():
+            if self.support_arg:
+                if not issubclass(kls, CMDArg) and "var" in data:
+                    continue
+            else:
+                if issubclass(kls, CMDArg):
+                    continue
+            try:
+                kls_claim = kls._claim_polymorphic
+            except AttributeError:
+                if not fallback:
+                    fallback = kls
+            else:
+                if kls_claim(data):
+                    matching_classes.add(kls)
+
+        if not matching_classes and fallback:
+            return fallback
+        elif len(matching_classes) != 1:
+            raise Exception("Got ambiguous input for polymorphic field")
+
+        return matching_classes.pop()
+
+
 class CMDArg(CMDArgBase):
     # properties as tags
     var = CMDVariantField(required=True)
@@ -210,7 +254,7 @@ class CMDClsArgBase(CMDArgBase):
         return arg
 
 
-class CMDClsArg(CMDArg, CMDClsArgBase):
+class CMDClsArg(CMDClsArgBase, CMDArg):
     pass
 
 
@@ -239,7 +283,7 @@ class CMDStringArgBase(CMDArgBase):
             self.enum.reformat()
 
 
-class CMDStringArg(CMDArg, CMDStringArgBase):
+class CMDStringArg(CMDStringArgBase, CMDArg):
     pass
 
 
@@ -248,7 +292,7 @@ class CMDByteArgBase(CMDStringArgBase):
     TYPE_VALUE = "byte"
 
 
-class CMDByteArg(CMDStringArg, CMDByteArgBase):
+class CMDByteArg(CMDByteArgBase, CMDStringArg):
     pass
 
 
@@ -257,7 +301,7 @@ class CMDBinaryArgBase(CMDStringArgBase):
     TYPE_VALUE = "binary"
 
 
-class CMDBinaryArg(CMDStringArg, CMDBinaryArgBase):
+class CMDBinaryArg(CMDBinaryArgBase, CMDStringArg):
     pass
 
 
@@ -266,7 +310,7 @@ class CMDDurationArgBase(CMDStringArgBase):
     TYPE_VALUE = "duration"
 
 
-class CMDDurationArg(CMDStringArg, CMDDurationArgBase):
+class CMDDurationArg(CMDDurationArgBase, CMDStringArg):
     pass
 
 
@@ -275,7 +319,7 @@ class CMDDateArgBase(CMDStringArgBase):
     TYPE_VALUE = "date"
 
 
-class CMDDateArg(CMDStringArg, CMDDateArgBase):
+class CMDDateArg(CMDDateArgBase, CMDStringArg):
     pass
 
 
@@ -284,7 +328,7 @@ class CMDDateTimeArgBase(CMDStringArgBase):
     TYPE_VALUE = "dateTime"
 
 
-class CMDDateTimeArg(CMDStringArg, CMDDateTimeArgBase):
+class CMDDateTimeArg(CMDDateTimeArgBase, CMDStringArg):
     pass
 
 
@@ -293,7 +337,7 @@ class CMDUuidArgBase(CMDStringArgBase):
     TYPE_VALUE = "uuid"
 
 
-class CMDUuidArg(CMDStringArg, CMDUuidArgBase):
+class CMDUuidArg(CMDUuidArgBase, CMDStringArg):
     pass
 
 
@@ -302,7 +346,7 @@ class CMDPasswordArgBase(CMDStringArgBase):
     TYPE_VALUE = "password"
 
 
-class CMDPasswordArg(CMDStringArg, CMDPasswordArgBase):
+class CMDPasswordArg(CMDPasswordArgBase, CMDStringArg):
     pass
 
 
@@ -311,7 +355,7 @@ class CMDSubscriptionIdArgBase(CMDStringArgBase):
     TYPE_VALUE = "subscriptionId"
 
 
-class CMDSubscriptionIdArg(CMDStringArg, CMDSubscriptionIdArgBase):
+class CMDSubscriptionIdArg(CMDSubscriptionIdArgBase, CMDStringArg):
     pass
 
 
@@ -320,7 +364,7 @@ class CMDResourceGroupNameArgBase(CMDStringArgBase):
     TYPE_VALUE = "resourceGroupName"
 
 
-class CMDResourceGroupNameArg(CMDStringArg, CMDResourceGroupNameArgBase):
+class CMDResourceGroupNameArg(CMDResourceGroupNameArgBase, CMDStringArg):
     pass
 
 
@@ -335,7 +379,7 @@ class CMDResourceIdArgBase(CMDStringArgBase):
     )
 
 
-class CMDResourceIdArg(CMDStringArg, CMDResourceIdArgBase):
+class CMDResourceIdArg(CMDResourceIdArgBase, CMDStringArg):
     pass
 
 
@@ -344,7 +388,7 @@ class CMDResourceLocationArgBase(CMDStringArgBase):
     TYPE_VALUE = "resourceLocation"
 
 
-class CMDResourceLocationArg(CMDStringArg, CMDResourceLocationArgBase):
+class CMDResourceLocationArg(CMDResourceLocationArgBase, CMDStringArg):
 
     @classmethod
     def build_arg(cls, builder):
@@ -380,7 +424,7 @@ class CMDIntegerArgBase(CMDArgBase):
             self.enum.reformat()
 
 
-class CMDIntegerArg(CMDArg, CMDIntegerArgBase):
+class CMDIntegerArg(CMDIntegerArgBase, CMDArg):
     pass
 
 
@@ -389,7 +433,7 @@ class CMDInteger32ArgBase(CMDIntegerArgBase):
     TYPE_VALUE = "integer32"
 
 
-class CMDInteger32Arg(CMDIntegerArg, CMDInteger32ArgBase):
+class CMDInteger32Arg(CMDInteger32ArgBase, CMDIntegerArg):
     pass
 
 
@@ -398,7 +442,7 @@ class CMDInteger64ArgBase(CMDIntegerArgBase):
     TYPE_VALUE = "integer64"
 
 
-class CMDInteger64Arg(CMDIntegerArg, CMDInteger64ArgBase):
+class CMDInteger64Arg(CMDInteger64ArgBase, CMDIntegerArg):
     pass
 
 
@@ -407,7 +451,7 @@ class CMDBooleanArgBase(CMDArgBase):
     TYPE_VALUE = "boolean"
 
 
-class CMDBooleanArg(CMDArg, CMDBooleanArgBase):
+class CMDBooleanArg(CMDBooleanArgBase, CMDArg):
     pass
 
 
@@ -436,7 +480,7 @@ class CMDFloatArgBase(CMDArgBase):
             self.enum.reformat()
 
 
-class CMDFloatArg(CMDArg, CMDFloatArgBase):
+class CMDFloatArg(CMDFloatArgBase, CMDArg):
     pass
 
 
@@ -445,7 +489,7 @@ class CMDFloat32ArgBase(CMDFloatArgBase):
     TYPE_VALUE = "float32"
 
 
-class CMDFloat32Arg(CMDFloatArg, CMDFloat32ArgBase):
+class CMDFloat32Arg(CMDFloat32ArgBase, CMDFloatArg):
     pass
 
 
@@ -454,14 +498,14 @@ class CMDFloat64ArgBase(CMDFloatArgBase):
     TYPE_VALUE = "float64"
 
 
-class CMDFloat64Arg(CMDFloatArg, CMDFloat64ArgBase):
+class CMDFloat64Arg(CMDFloat64ArgBase, CMDFloatArg):
     pass
 
 
 # object
 class CMDObjectArgAdditionalProperties(Model):
     # properties as nodes
-    item = PolyModelType(CMDArgBase, allow_subclasses=True)
+    item = CMDArgBaseField()
 
     class Options:
         serialize_when_none = False
@@ -514,7 +558,7 @@ class CMDObjectArgBase(CMDArgBase):
             self.additional_props.reformat()
 
 
-class CMDObjectArg(CMDArg, CMDObjectArgBase):
+class CMDObjectArg(CMDObjectArgBase, CMDArg):
 
     cls = CMDClassField()  # define a class which can be used by loop
 
@@ -535,7 +579,8 @@ class CMDArrayArgBase(CMDArgBase):
         serialized_name='format',
         deserialize_from='format',
     )
-    item = PolyModelType(CMDArgBase, allow_subclasses=True, required=True)
+
+    item = CMDArgBaseField(required=True)
 
     def _get_type(self):
         return f"{self.TYPE_VALUE}<{self.item.type}>"
@@ -553,7 +598,7 @@ class CMDArrayArgBase(CMDArgBase):
         self.item.reformat()
 
 
-class CMDArrayArg(CMDArg, CMDArrayArgBase):
+class CMDArrayArg(CMDArrayArgBase, CMDArg):
 
     singular_options = ListType(
         StringType(),

--- a/src/backend/command/model/configuration/_content.py
+++ b/src/backend/command/model/configuration/_content.py
@@ -6,8 +6,7 @@ from ._schema import CMDSchemaBaseField, CMDSchema, CMDSchemaBase
 from ._utils import CMDDiffLevelEnum
 
 
-# json
-class CMDJson(Model):
+class CMDRequestJson(Model):
     # properties as tags
     var = CMDVariantField()
     ref = CMDVariantField()
@@ -47,4 +46,27 @@ class CMDJson(Model):
                 diff["var"] = f"{old.var} != {self.var}"
             if self.ref != old.ref:
                 diff["ref"] = f"{old.ref} != {self.ref}"
+        return diff
+
+
+class CMDResponseJson(Model):
+    # properties as tags
+    var = CMDVariantField()
+
+    # properties as nodes
+    schema = CMDSchemaBaseField(required=True)
+
+    class Options:
+        serialize_when_none = False
+
+    def diff(self, old, level):
+        diff = {}
+        if level >= CMDDiffLevelEnum.BreakingChange:
+            schema_diff = self.schema.diff(old.schema, level)
+            if schema_diff:
+                diff["schema"] = schema_diff
+
+        if level >= CMDDiffLevelEnum.Associate:
+            if self.var != old.var:
+                diff["var"] = f"{old.var} != {self.var}"
         return diff

--- a/src/backend/command/model/configuration/_content.py
+++ b/src/backend/command/model/configuration/_content.py
@@ -1,21 +1,20 @@
 from schematics.models import Model
+from schematics.types import PolyModelType
 
 from ._arg_builder import CMDArgBuilder
 from ._fields import CMDVariantField
-from ._schema import CMDSchemaBaseField, CMDSchema, CMDSchemaBase
+from ._schema import CMDSchemaBaseField, CMDSchema
 from ._utils import CMDDiffLevelEnum
 
 
 class CMDRequestJson(Model):
+    """Used for Request Body and Instance Update operation"""
+
     # properties as tags
-    var = CMDVariantField()
     ref = CMDVariantField()
 
     # properties as nodes
-    schema = CMDSchemaBaseField(support_schema=True)  # this property is required when ref property is None
-    # Note: the schema can be CMDSchema or CMDSchemaBase.
-    # For request or instance update, it's CMDSchema.
-    # For response, it's CMDSchemaBase.
+    schema = PolyModelType(CMDSchema, allow_subclasses=True)
 
     class Options:
         serialize_when_none = False
@@ -33,17 +32,11 @@ class CMDRequestJson(Model):
         if level >= CMDDiffLevelEnum.BreakingChange:
             if (self.ref is not None) != (old.ref is not None):
                 diff["ref"] = f"{old.ref} != {self.ref}"
-
-            if isinstance(self.schema, CMDSchema) and isinstance(old.schema, CMDSchema) or isinstance(self.schema, CMDSchemaBase) and isinstance(old.schema, CMDSchemaBase):
-                schema_diff = self.schema.diff(old.schema, level)
-                if schema_diff:
-                    diff["schema"] = schema_diff
-            elif self.schema is not None or old.schema is not None:
-                diff["schema"] = f"Different type: {type(old.schema)} != {type(self.schema)}"
+            schema_diff = self.schema.diff(old.schema, level)
+            if schema_diff:
+                diff["schema"] = schema_diff
 
         if level >= CMDDiffLevelEnum.Associate:
-            if self.var != old.var:
-                diff["var"] = f"{old.var} != {self.var}"
             if self.ref != old.ref:
                 diff["ref"] = f"{old.ref} != {self.ref}"
         return diff

--- a/src/backend/command/model/configuration/_http.py
+++ b/src/backend/command/model/configuration/_http.py
@@ -6,7 +6,8 @@ from schematics.models import Model
 from schematics.types import StringType, ModelType, ListType, PolyModelType, IntType
 
 from ._fields import CMDVariantField, CMDBooleanField, CMDURLPathField, CMDDescriptionField
-from ._http_body import CMDHttpBody
+from ._http_request_body import CMDHttpRequestBody
+from ._http_response_body import CMDHttpResponseBody
 from ._schema import CMDSchemaField
 from ._arg_builder import CMDArgBuilder
 from ._arg import CMDResourceGroupNameArg, CMDSubscriptionIdArg, CMDResourceLocationArg
@@ -114,7 +115,7 @@ class CMDHttpRequest(Model):
     path = ModelType(CMDHttpRequestPath)
     query = ModelType(CMDHttpRequestQuery)
     header = ModelType(CMDHttpRequestHeader)
-    body = PolyModelType(CMDHttpBody, allow_subclasses=True)
+    body = PolyModelType(CMDHttpRequestBody, allow_subclasses=True)
 
     class Options:
         serialize_when_none = False
@@ -202,7 +203,7 @@ class CMDHttpResponse(Model):
 
     # properties as nodes
     header = ModelType(CMDHttpResponseHeader)
-    body = PolyModelType(CMDHttpBody, allow_subclasses=True)
+    body = PolyModelType(CMDHttpResponseBody, allow_subclasses=True)
 
     class Options:
         serialize_when_none = False

--- a/src/backend/command/model/configuration/_http_request_body.py
+++ b/src/backend/command/model/configuration/_http_request_body.py
@@ -1,10 +1,10 @@
 from schematics.models import Model
 from schematics.types import ModelType
 
-from ._content import CMDJson
+from ._content import CMDRequestJson
 
 
-class CMDHttpBody(Model):
+class CMDHttpRequestBody(Model):
     POLYMORPHIC_KEY = None
 
     @classmethod
@@ -14,7 +14,7 @@ class CMDHttpBody(Model):
 
         if isinstance(data, dict):
             return cls.POLYMORPHIC_KEY in data
-        elif isinstance(data, CMDHttpBody):
+        elif isinstance(data, CMDHttpRequestBody):
             return hasattr(data, cls.POLYMORPHIC_KEY)
 
         return False
@@ -26,10 +26,10 @@ class CMDHttpBody(Model):
         raise NotImplementedError()
 
 
-class CMDHttpJsonBody(CMDHttpBody):
+class CMDHttpRequestJsonBody(CMDHttpRequestBody):
     POLYMORPHIC_KEY = "json"
 
-    json = ModelType(CMDJson, required=True)
+    json = ModelType(CMDRequestJson, required=True)
 
     def generate_args(self):
         return self.json.generate_args()

--- a/src/backend/command/model/configuration/_http_response_body.py
+++ b/src/backend/command/model/configuration/_http_response_body.py
@@ -1,0 +1,34 @@
+from schematics.models import Model
+from schematics.types import ModelType
+
+from ._content import CMDResponseJson
+
+
+class CMDHttpResponseBody(Model):
+    POLYMORPHIC_KEY = None
+
+    @classmethod
+    def _claim_polymorphic(cls, data):
+        if cls.POLYMORPHIC_KEY is None:
+            return False
+
+        if isinstance(data, dict):
+            return cls.POLYMORPHIC_KEY in data
+        elif isinstance(data, CMDHttpResponseBody):
+            return hasattr(data, cls.POLYMORPHIC_KEY)
+
+        return False
+
+    def diff(self, old, level):
+        raise NotImplementedError()
+
+
+class CMDHttpResponseJsonBody(CMDHttpResponseBody):
+    POLYMORPHIC_KEY = "json"
+
+    json = ModelType(CMDResponseJson, required=True)
+
+    def diff(self, old, level):
+        if not isinstance(old, self.__class__):
+            return f"Response type changed: '{type(old)}' != '{self.__class__}'"
+        return self.json.diff(old.json, level)

--- a/src/backend/command/model/configuration/_instance_update.py
+++ b/src/backend/command/model/configuration/_instance_update.py
@@ -6,7 +6,7 @@ from schematics.models import Model
 from schematics.types import ModelType
 
 from ._fields import CMDVariantField, CMDBooleanField
-from ._content import CMDJson
+from ._content import CMDRequestJson
 from ._arg import CMDClsArg
 
 
@@ -36,7 +36,7 @@ class CMDJsonInstanceUpdateAction(CMDInstanceUpdateAction):
     POLYMORPHIC_KEY = "json"
 
     # properties as nodes
-    json = ModelType(CMDJson, required=True)
+    json = ModelType(CMDRequestJson, required=True)
 
     def generate_args(self):
         return self.json.generate_args()

--- a/src/backend/command/model/configuration/_schema.py
+++ b/src/backend/command/model/configuration/_schema.py
@@ -335,7 +335,7 @@ class CMDClsSchemaBase(CMDSchemaBase):
         return False
 
 
-class CMDClsSchema(CMDSchema, CMDClsSchemaBase):
+class CMDClsSchema(CMDClsSchemaBase, CMDSchema):
     ARG_TYPE = CMDClsArg
 
     # properties as tags
@@ -380,7 +380,7 @@ class CMDStringSchemaBase(CMDSchemaBase):
         return diff
 
 
-class CMDStringSchema(CMDSchema, CMDStringSchemaBase):
+class CMDStringSchema(CMDStringSchemaBase, CMDSchema):
     ARG_TYPE = CMDStringArg
 
 
@@ -390,7 +390,7 @@ class CMDByteSchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDByteArgBase
 
 
-class CMDByteSchema(CMDStringSchema, CMDByteSchemaBase):
+class CMDByteSchema(CMDByteSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDByteArg
 
 
@@ -400,7 +400,7 @@ class CMDBinarySchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDBinaryArgBase
 
 
-class CMDBinarySchema(CMDStringSchema, CMDBinarySchemaBase):
+class CMDBinarySchema(CMDBinarySchemaBase, CMDStringSchema):
     ARG_TYPE = CMDBinaryArg
 
 
@@ -410,7 +410,7 @@ class CMDDurationSchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDDurationArgBase
 
 
-class CMDDurationSchema(CMDStringSchema, CMDDurationSchemaBase):
+class CMDDurationSchema(CMDDurationSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDDurationArg
 
 
@@ -420,7 +420,7 @@ class CMDDateSchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDDateArgBase
 
 
-class CMDDateSchema(CMDStringSchema, CMDDateSchemaBase):
+class CMDDateSchema(CMDDateSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDDateArg
 
 
@@ -430,7 +430,7 @@ class CMDDateTimeSchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDDateTimeArgBase
 
 
-class CMDDateTimeSchema(CMDStringSchema, CMDDateTimeSchemaBase):
+class CMDDateTimeSchema(CMDDateTimeSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDDateTimeArg
 
 
@@ -440,7 +440,7 @@ class CMDUuidSchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDUuidArgBase
 
 
-class CMDUuidSchema(CMDStringSchema, CMDUuidSchemaBase):
+class CMDUuidSchema(CMDUuidSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDUuidArg
 
 
@@ -450,7 +450,7 @@ class CMDPasswordSchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDPasswordArgBase
 
 
-class CMDPasswordSchema(CMDStringSchema, CMDPasswordSchemaBase):
+class CMDPasswordSchema(CMDPasswordSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDPasswordArg
 
 
@@ -466,7 +466,7 @@ class CMDResourceIdSchemaBase(CMDStringSchemaBase):
     )
 
 
-class CMDResourceIdSchema(CMDResourceIdSchemaBase, CMDStringSchema,):
+class CMDResourceIdSchema(CMDResourceIdSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDResourceIdArg
 
 
@@ -476,7 +476,7 @@ class CMDResourceLocationSchemaBase(CMDStringSchemaBase):
     ARG_TYPE = CMDResourceLocationArgBase
 
 
-class CMDResourceLocationSchema(CMDStringSchema, CMDResourceLocationSchemaBase):
+class CMDResourceLocationSchema(CMDResourceLocationSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDResourceLocationArg
 
 
@@ -506,7 +506,7 @@ class CMDIntegerSchemaBase(CMDSchemaBase):
         return diff
 
 
-class CMDIntegerSchema(CMDSchema, CMDIntegerSchemaBase):
+class CMDIntegerSchema(CMDIntegerSchemaBase, CMDSchema):
     ARG_TYPE = CMDIntegerArg
 
 
@@ -516,7 +516,7 @@ class CMDInteger32SchemaBase(CMDIntegerSchemaBase):
     ARG_TYPE = CMDInteger32ArgBase
 
 
-class CMDInteger32Schema(CMDIntegerSchema, CMDInteger32SchemaBase):
+class CMDInteger32Schema(CMDInteger32SchemaBase, CMDIntegerSchema):
     ARG_TYPE = CMDInteger32Arg
 
 
@@ -526,7 +526,7 @@ class CMDInteger64SchemaBase(CMDIntegerSchemaBase):
     ARG_TYPE = CMDInteger64ArgBase
 
 
-class CMDInteger64Schema(CMDIntegerSchema, CMDInteger64SchemaBase):
+class CMDInteger64Schema(CMDInteger64SchemaBase, CMDIntegerSchema):
     ARG_TYPE = CMDInteger64Arg
 
 
@@ -536,7 +536,7 @@ class CMDBooleanSchemaBase(CMDSchemaBase):
     ARG_TYPE = CMDBooleanArgBase
 
 
-class CMDBooleanSchema(CMDSchema, CMDBooleanSchemaBase):
+class CMDBooleanSchema(CMDBooleanSchemaBase, CMDSchema):
     ARG_TYPE = CMDBooleanArg
 
 
@@ -566,7 +566,7 @@ class CMDFloatSchemaBase(CMDSchemaBase):
         return diff
 
 
-class CMDFloatSchema(CMDSchema, CMDFloatSchemaBase):
+class CMDFloatSchema(CMDFloatSchemaBase, CMDSchema):
     ARG_TYPE = CMDFloatArg
 
 
@@ -576,7 +576,7 @@ class CMDFloat32SchemaBase(CMDFloatSchemaBase):
     ARG_TYPE = CMDFloat32ArgBase
 
 
-class CMDFloat32Schema(CMDFloatSchema, CMDFloat32SchemaBase):
+class CMDFloat32Schema(CMDFloat32SchemaBase, CMDFloatSchema):
     ARG_TYPE = CMDFloat32Arg
 
 
@@ -586,7 +586,7 @@ class CMDFloat64SchemaBase(CMDFloatSchemaBase):
     ARG_TYPE = CMDFloat64ArgBase
 
 
-class CMDFloat64Schema(CMDFloatSchema, CMDFloat64SchemaBase):
+class CMDFloat64Schema(CMDFloat64SchemaBase, CMDFloatSchema):
     ARG_TYPE = CMDFloat64Arg
 
 
@@ -769,7 +769,7 @@ class CMDObjectSchemaBase(CMDSchemaBase):
         return diff
 
 
-class CMDObjectSchema(CMDSchema, CMDObjectSchemaBase):
+class CMDObjectSchema(CMDObjectSchemaBase, CMDSchema):
     ARG_TYPE = CMDObjectArg
 
     # properties as tags
@@ -831,7 +831,7 @@ class CMDArraySchemaBase(CMDSchemaBase):
         return diff
 
 
-class CMDArraySchema(CMDSchema, CMDArraySchemaBase):
+class CMDArraySchema(CMDArraySchemaBase, CMDSchema):
     ARG_TYPE = CMDArrayArg
 
     def _diff(self, old, level, diff):

--- a/src/backend/command/model/configuration/_schema.py
+++ b/src/backend/command/model/configuration/_schema.py
@@ -190,14 +190,13 @@ class CMDSchemaBase(Model):
 
 class CMDSchemaBaseField(PolyModelType):
 
-    def __init__(self, support_schema=False, **kwargs):
+    def __init__(self, **kwargs):
         super(CMDSchemaBaseField, self).__init__(
             model_spec=CMDSchemaBase,
             allow_subclasses=True,
             serialize_when_none=False,
             **kwargs
         )
-        self.support_schema = support_schema
 
     def export(self, value, format, context=None):
         if value.frozen:
@@ -215,12 +214,9 @@ class CMDSchemaBaseField(PolyModelType):
         fallback = None
         matching_classes = set()
         for kls in self._get_candidates():
-            if self.support_schema:
-                if not issubclass(kls, CMDSchema) and "name" in data:
-                    continue
-            else:
-                if issubclass(kls, CMDSchema):
-                    continue
+            if issubclass(kls, CMDSchema):
+                continue
+
             try:
                 kls_claim = kls._claim_polymorphic
             except AttributeError:

--- a/src/backend/swagger/controller/command_generator.py
+++ b/src/backend/swagger/controller/command_generator.py
@@ -1,12 +1,11 @@
 import logging
 
 import inflect
-from command.model.configuration import CMDCommandGroup, CMDCommand, CMDHttpOperation, CMDHttpRequest, \
-    CMDSchemaDefault, CMDHttpJsonBody, CMDObjectOutput, CMDArrayOutput, CMDGenericInstanceUpdateAction, \
-    CMDGenericInstanceUpdateMethod, CMDJsonInstanceUpdateAction, CMDInstanceUpdateOperation, CMDJson, CMDArgGroup, \
-    CMDDiffLevelEnum, CMDClsSchemaBase, \
-    CMDObjectSchema, CMDArraySchema, CMDStringSchema, CMDObjectSchemaBase, CMDArraySchemaBase, CMDStringSchemaBase, \
-    CMDStringOutput
+from command.model.configuration import CMDCommandGroup, CMDCommand, CMDHttpOperation, CMDHttpRequest, CMDSchemaDefault, \
+    CMDHttpResponseJsonBody, CMDObjectOutput, CMDArrayOutput, CMDGenericInstanceUpdateAction, \
+    CMDGenericInstanceUpdateMethod, CMDJsonInstanceUpdateAction, CMDInstanceUpdateOperation, CMDRequestJson, \
+    CMDArgGroup, CMDDiffLevelEnum, CMDClsSchemaBase, CMDArraySchema, CMDStringSchema, CMDObjectSchemaBase, \
+    CMDArraySchemaBase, CMDStringSchemaBase, CMDStringOutput
 from swagger.model.schema.cmd_builder import CMDBuilder
 from swagger.model.schema.fields import MutabilityEnum
 from swagger.model.schema.path_item import PathItem
@@ -216,9 +215,9 @@ class CommandGenerator:
             for resp in op.http.responses:
                 if resp.is_error:
                     continue
-                if not isinstance(resp.body, CMDHttpJsonBody):
+                if not isinstance(resp.body, CMDHttpResponseJsonBody):
                     continue
-                if not isinstance(resp.body.json.schema, CMDObjectSchema):
+                if not isinstance(resp.body.json.schema, CMDObjectSchemaBase):
                     continue
                 body_schema = resp.body.json.schema
                 if not body_schema.props:
@@ -241,7 +240,7 @@ class CommandGenerator:
                 continue
             if resp.body is None:
                 continue
-            if isinstance(resp.body, CMDHttpJsonBody):
+            if isinstance(resp.body, CMDHttpResponseJsonBody):
                 body_json = resp.body.json
                 body_json.var = BuildInVariants.Instance
                 if pageable and pageable.item_name:
@@ -472,7 +471,7 @@ class CommandGenerator:
         json_update_op = CMDInstanceUpdateOperation()
         json_update_op.instance_update = CMDJsonInstanceUpdateAction()
         json_update_op.instance_update.instance = BuildInVariants.Instance
-        json_update_op.instance_update.json = CMDJson()
+        json_update_op.instance_update.json = CMDRequestJson()
         json_update_op.instance_update.json.schema = put_op.http.request.body.json.schema
 
         generic_update_op = CMDInstanceUpdateOperation()

--- a/src/backend/swagger/model/schema/operation.py
+++ b/src/backend/swagger/model/schema/operation.py
@@ -2,7 +2,7 @@ from schematics.models import Model
 from schematics.types import StringType, ModelType, ListType, DictType, BooleanType, PolyModelType
 
 from command.model.configuration import CMDHttpOperation, CMDHttpAction, CMDHttpRequest, CMDHttpRequestPath, \
-    CMDHttpRequestQuery, CMDHttpRequestHeader, CMDHttpJsonBody, CMDJson, CMDHttpOperationLongRunning
+    CMDHttpRequestQuery, CMDHttpRequestHeader, CMDHttpRequestJsonBody, CMDRequestJson, CMDHttpOperationLongRunning
 from swagger.utils import exceptions
 from swagger.utils.tools import swagger_resource_path_to_resource_id_template
 from .external_documentation import ExternalDocumentation
@@ -191,8 +191,8 @@ class Operation(Model, Linkable):
                     value=[builder.path, builder.method, builder.mutability, *param_models[BodyParameter.IN_VALUE].keys()]
                 )
             model = [*param_models[BodyParameter.IN_VALUE].values()][0]
-            if isinstance(model, CMDJson):
-                request.body = CMDHttpJsonBody()
+            if isinstance(model, CMDRequestJson):
+                request.body = CMDHttpRequestJsonBody()
                 request.body.json = model
             else:
                 raise NotImplementedError()

--- a/src/backend/swagger/model/schema/parameter.py
+++ b/src/backend/swagger/model/schema/parameter.py
@@ -1,6 +1,6 @@
 import logging
 
-from command.model.configuration import CMDJson, CMDBooleanSchema, CMDStringSchema, CMDObjectSchema, \
+from command.model.configuration import CMDRequestJson, CMDBooleanSchema, CMDStringSchema, CMDObjectSchema, \
     CMDArraySchema, CMDFloatSchema, CMDIntegerSchema
 from schematics.models import Model
 from schematics.types import StringType, BooleanType, ModelType, PolyModelType, BaseType
@@ -97,13 +97,6 @@ class QueryParameter(Items, ParameterBase):
 
         return model
 
-    # def to_cmd_model(self, mutability):
-    #     param = self.to_cmd_param(mutability)
-    #
-    #     param.name = self.name
-    #     param.required = self.required
-    #     param.description = self.description
-
 
 class HeaderParameter(Items, ParameterBase):
     """Custom headers that are expected as part of the request."""
@@ -125,21 +118,6 @@ class HeaderParameter(Items, ParameterBase):
         builder.setup_description(model, self)
         return model
 
-    # def to_cmd_model(self, mutability):
-    #     param = self.to_cmd_param(mutability)
-    #
-    #     param.name = self.name
-    #     param.required = self.required
-    #     param.description = self.description
-    #
-    #     if self.x_ms_client_default is not None:
-    #         param.default = CMDSchemaDefault()
-    #         param.default.value = self.x_ms_client_default
-    #     if self.description and isinstance(param, CMDSchema):
-    #         param.description = self.description
-    #
-    #     return param
-
 
 class PathParameter(Items, ParameterBase):
     """Used together with Path Templating, where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in /items/{itemId}, the path parameter is itemId."""
@@ -160,24 +138,6 @@ class PathParameter(Items, ParameterBase):
             model.skip_url_encoding = False
 
         return model
-
-    # def to_cmd_model(self, mutability):
-    #     param = self.to_cmd_param(mutability)
-    #     param.name = self.name
-    #     param.required = self.required
-    #     param.description = self.description
-    #
-    #     if self.x_ms_skip_url_encoding:
-    #         param.skip_url_encoding = False
-    #
-    #     if self.x_ms_client_default is not None:
-    #         param.default = CMDSchemaDefault()
-    #         param.default.value = self.x_ms_client_default
-    #
-    #     if self.description and isinstance(param, CMDSchema):
-    #         param.description = self.description
-    #
-    #     return param
 
 
 class FormDataParameter(Items, ParameterBase):
@@ -248,7 +208,7 @@ class BodyParameter(ParameterBase, Linkable):
                 CMDFloatSchema,
                 CMDIntegerSchema
         )):
-            model = CMDJson()
+            model = CMDRequestJson()
             model.schema = v
             if isinstance(v, CMDObjectSchema):
                 # flatten body parameter

--- a/src/backend/swagger/model/schema/response.py
+++ b/src/backend/swagger/model/schema/response.py
@@ -1,9 +1,9 @@
 from schematics.models import Model
 from schematics.types import BaseType, StringType, ModelType, DictType, PolyModelType
 
-from command.model.configuration import CMDHttpResponse, CMDHttpResponseHeader, CMDHttpJsonBody, CMDObjectSchemaBase, \
+from command.model.configuration import CMDHttpResponse, CMDHttpResponseHeader, CMDHttpResponseJsonBody, CMDObjectSchemaBase, \
     CMDArraySchemaBase, CMDHttpResponseHeaderItem, CMDClsSchemaBase
-from command.model.configuration import CMDJson, CMDBooleanSchemaBase, CMDStringSchemaBase, CMDFloatSchemaBase, \
+from command.model.configuration import CMDResponseJson, CMDBooleanSchemaBase, CMDStringSchemaBase, CMDFloatSchemaBase, \
     CMDIntegerSchemaBase
 from swagger.model.schema.fields import MutabilityEnum
 from swagger.utils import exceptions
@@ -86,7 +86,7 @@ class Response(Model, Linkable):
                     CMDIntegerSchemaBase,
                     CMDClsSchemaBase,
             )):
-                model = CMDJson()
+                model = CMDResponseJson()
                 model.schema = v
             else:
                 raise exceptions.InvalidSwaggerValueError(
@@ -95,8 +95,8 @@ class Response(Model, Linkable):
                     value=v.type
                 )
 
-            if isinstance(model, CMDJson):
-                response.body = CMDHttpJsonBody()
+            if isinstance(model, CMDResponseJson):
+                response.body = CMDHttpResponseJsonBody()
                 response.body.json = model
             else:
                 raise NotImplementedError()


### PR DESCRIPTION
1. Change the order for model multiple inheritance. Because in Schematic library, the fields inherited from bases are overwritten reversed:
```python
        # Accumulate metas info from parent classes
        for base in reversed(bases):
            if hasattr(base, '_schema'):
                fields.update(deepcopy(base._schema.fields))
                options_members.update(dict(base._schema.options))
                validator_functions.update(base._schema.validators)
````
2. Add CMDArgBaseField
3. Use `CMDRequestJson` and `CMDResponseJson` instead of `CMDJson`
4. Use `CMDHttpRequestBody` and `CMDHttpResponseBody` instead of `CMDHttpBody`
5. Use `CMDHttpRequestJsonBody` and `CMDHttpResponseJsonBody` instead of `CMDHttpJsonBody`