### PR TITLE
Optimize `aaz-dev run` command

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.1.2
+++++
+* Support `--quiet` argument in aaz-dev run to disable web browser page opening.
+* Raise error when port is used by others.
+
 0.1.1
 +++++
 * Use Jinja version 3.0.3;

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "1", "1", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "1", "2", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Support `--quiet` argument in aaz-dev run to disable web browser page opening.
* Raise error when port is used by others.